### PR TITLE
PR: Initial package structure, CLI and interface ideas

### DIFF
--- a/.github/tests.yml
+++ b/.github/tests.yml
@@ -1,9 +1,7 @@
 # Run the project's test suite
 name: Tests
 
-on:
-  push
-  pull_request
+on: [pull_request, pull]
 
 jobs:
   test:

--- a/.github/tests.yml
+++ b/.github/tests.yml
@@ -1,7 +1,7 @@
 # Run the project's test suite
 name: Tests
 
-on: [pull_request, pull]
+on: [pull_request, push]
 
 jobs:
   test:

--- a/.github/tests.yml
+++ b/.github/tests.yml
@@ -1,0 +1,34 @@
+# Run the project's test suite
+name: Tests
+
+on:
+  push
+  pull_request
+
+jobs:
+  test:
+    name: Test ${{ matrix.os }} Python ${{ matrix.python-version }} conda=${{ matrix.use-conda }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.7', '3.10']
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+      - name: Install Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+           auto-update-conda: true
+           channels: conda-forge
+           python-version: ${{ matrix.python-version }}
+      - name: Install env-manager and test dependencies
+        run: |
+        python -m pip install -e .[test]
+      - name: Run tests
+        run: |
+        pytest --cov=env_manager -vv

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 ## Installation
 
+*Note:* This package is not available yet for installation but it will be in the coming months.
 
 ### PyPI
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
 # env-manager
-A manager for Python environment and packages managers
+
+[![PyPI - Version](https://img.shields.io/pypi/v/env-manager.svg)](https://pypi.org/project/env-manager)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/env-manager.svg)](https://pypi.org/project/env-manager)
+[![conda version](https://img.shields.io/conda/vn/conda-forge/env-manager.svg)](https://www.anaconda.com/conda-forge/env-manager)
+[![download count](https://img.shields.io/conda/dn/conda-forge/env-manager.svg)](https://www.anaconda.com/conda-forge/env-manager)
+
+-----
+
+**Table of Contents**
+
+- [Installation](#installation)
+    - [PyPI](#pypi)
+    - [Conda](#conda)
+- [Development](#development)
+- [License](#license)
+
+## Installation
+
+
+### PyPI
+
+```console
+pip install env-manager
+```
+
+### Conda
+
+```console
+conda install -c conda-forge env-manager
+```
+
+## Development
+
+* Fork and clone the repo. To clone:
+
+```console
+git clone <link to your fork.git>
+cd env-manager
+```
+
+* Create a Python environment and activate it. For example with conda:
+
+```console
+conda create -n env-manager -c conda-forge python
+conda activate env-manager
+```
+
+* Install development version and test dependencies:
+
+```console
+pip install -e .[test]
+```
+
+* To check the CLI options:
+
+```console
+env-manager --help
+```
+
+* To run the test:
+
+```console
+pytest -vv
+```
+
+## License
+
+`env-manager` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/env_manager/__about__.py
+++ b/env_manager/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT
+__version__ = '0.0.1'

--- a/env_manager/__init__.py
+++ b/env_manager/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT

--- a/env_manager/api.py
+++ b/env_manager/api.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT
+
+class EnvManagerInstance:
+    ID = ''
+
+    def __init__(self, executable_path=None):
+        self.executable = executable_path
+        assert self.validate(), f"{self.ID} backend unavailable!"
+
+    def validate(self):
+        pass
+
+    def create_environment(self, environment_path, packages=None, channels=None):
+        raise NotImplementedError()
+
+    def delete_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def activate_environment(self):
+        raise NotImplementedError()
+    
+    def deactivate_environment(self):
+        raise NotImplementedError()
+
+    def export_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def import_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def install_packages(self, environment_path, packages, channels=None):
+        raise NotImplementedError()
+
+    def uninstall_packages(self, environment_path, packages):
+        raise NotImplementedError()
+    
+    def list_packages(self, environment_path):
+        raise NotImplementedError()
+
+

--- a/env_manager/backends/__init__.py
+++ b/env_manager/backends/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT

--- a/env_manager/backends/mamba_interface.py
+++ b/env_manager/backends/mamba_interface.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT
+
+import os.path as osp
+
+from env_manager.api import EnvManagerInstance
+
+class MambaInterface(EnvManagerInstance):
+    ID = 'MAMBA'
+
+    def validate(self):
+        try:
+            import mamba
+            return True
+        except:
+            return False
+
+    def create_environment(self, environment_path, packages=(), channels=('conda-forge',)):
+        from mamba.api import create
+        base_prefix = osp.dirname(osp.dirname(environment_path))
+        environment_name = osp.basename(environment_path)
+        create(environment_name, packages, channels, base_prefix=base_prefix)
+
+    def delete_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def activate_environment(self):
+        raise NotImplementedError()
+    
+    def deactivate_environment(self):
+        raise NotImplementedError()
+
+    def export_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def import_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def install_packages(self, environment_path, packages, channels=('conda-forge',)):
+        from mamba.api import install
+        base_prefix = osp.dirname(osp.dirname(environment_path))
+        environment_name = osp.basename(environment_path)
+        install(environment_name, packages, channels, base_prefix=base_prefix)
+    
+    def uninstall_packages(self, environment_path, packages):
+        from mamba.api import MambaSolver
+        base_prefix = osp.dirname(osp.dirname(environment_path))
+        environment_name = osp.basename(environment_path)
+        # TODO: Check https://github.com/mamba-org/mamba/blob/41d99c81d9652f73e38227d1b35cb3ff9b09b206/mamba/mamba/mamba.py#L130
+        # and https://github.com/mamba-org/mamba/blob/da44aadfaf88dfa3ce21656d671682626379cea6/mamba/mamba/api.py#L116
+    
+    def list_packages(self, environment_path):
+        from mamba.utils import get_installed_packages
+        _, result = get_installed_packages(environment_path)
+        list_result = list(result['packages'].keys())
+        print(*list_result, sep='\n')
+        return list_result
+

--- a/env_manager/backends/mamba_interface.py
+++ b/env_manager/backends/mamba_interface.py
@@ -7,7 +7,7 @@ import os.path as osp
 from env_manager.api import EnvManagerInstance
 
 class MambaInterface(EnvManagerInstance):
-    ID = 'MAMBA'
+    ID = 'mamba'
 
     def validate(self):
         try:

--- a/env_manager/backends/micromamba_interface.py
+++ b/env_manager/backends/micromamba_interface.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT
+
+from env_manager.api import EnvManagerInstance
+
+class MicromambaInterface(EnvManagerInstance):
+    ID = 'MICROMAMBA'
+
+    def validate(self):
+        pass
+
+    def create_environment(self, environment_path, packages=None, channels=None):
+        raise NotImplementedError()
+
+    def delete_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def activate_environment(self):
+        raise NotImplementedError()
+    
+    def deactivate_environment(self):
+        raise NotImplementedError()
+
+    def export_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def import_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def install_packages(self, environment_path, packages, channels=None):
+        raise NotImplementedError()
+
+    def uninstall_packages(self, environment_path, packages):
+        raise NotImplementedError()
+    
+    def list_packages(self, environment_path):
+        raise NotImplementedError()

--- a/env_manager/backends/micromamba_interface.py
+++ b/env_manager/backends/micromamba_interface.py
@@ -5,7 +5,7 @@
 from env_manager.api import EnvManagerInstance
 
 class MicromambaInterface(EnvManagerInstance):
-    ID = 'MICROMAMBA'
+    ID = 'micromamba'
 
     def validate(self):
         pass

--- a/env_manager/backends/venv_interface.py
+++ b/env_manager/backends/venv_interface.py
@@ -5,7 +5,7 @@
 from env_manager.api import EnvManagerInstance
 
 class VEnvInterface(EnvManagerInstance):
-    ID = 'VENV'
+    ID = 'venv'
 
     def validate(self):
         pass

--- a/env_manager/backends/venv_interface.py
+++ b/env_manager/backends/venv_interface.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT
+
+from env_manager.api import EnvManagerInstance
+
+class VEnvInterface(EnvManagerInstance):
+    ID = 'VENV'
+
+    def validate(self):
+        pass
+
+    def create_environment(self, environment_path, packages=None, channels=None):
+        raise NotImplementedError()
+
+    def delete_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def activate_environment(self):
+        raise NotImplementedError()
+    
+    def deactivate_environment(self):
+        raise NotImplementedError()
+
+    def export_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def import_environment(self, environment_path):
+        raise NotImplementedError()
+
+    def install_packages(self, environment_path, packages, channels=None):
+        raise NotImplementedError()
+
+    def uninstall_packages(self, environment_path, packages):
+        raise NotImplementedError()
+    
+    def list_packages(self, environment_path):
+        raise NotImplementedError()
+

--- a/env_manager/cli.py
+++ b/env_manager/cli.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT
+
+import argparse
+import os
+import os.path as osp
+import uuid
+
+from env_manager.manager import Manager
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(prog=__name__,
+                                    description='Manage a virtual Python '
+                                                'environment in a target '
+                                                'directory.')
+    parser.add_argument('-b', '--backend',
+                        default=os.environ.get('ENV_BACKEND', 'MAMBA'),
+                        choices=['VENV', 'MAMBA', 'MICROMAMBA'],
+                        help='The implementation to '
+                             'create/manage a virtual '
+                             'Python environment in the given '
+                             'directory.')
+    parser.add_argument('-ed', '--env_directory',
+                        default=os.environ.get('ENV_DIR',
+                                               osp.join(os.getcwd(), 'envs',
+                                                        str(uuid.uuid4()))),
+                        help='A directory where the virtual environment '
+                             'is or will be located following the structure '
+                             '<base path>/envs/<env name>.')
+
+    main_subparser = parser.add_subparsers(title='commands', dest='command')
+    # Create env
+    parser_create = main_subparser.add_parser('create',
+                                              help='Creates a virtual Python '
+                                                   'environment in the target '
+                                                   'directory.')
+    parser_create.add_argument('--packages', nargs='+',
+                               help='List of packages to install')
+    parser_create.add_argument('--channels', nargs='+',
+                               help='List of channels from where to install')
+
+    # Install packages
+    parser_install = main_subparser.add_parser('install',
+                                               help='Install packages in the '
+                                                    'virtual Python '
+                                                    'environment in the target '
+                                                    'directory.')
+    parser_install.add_argument('packages', nargs='+',
+                                help='List of packages to install')
+    parser_install.add_argument('--channels', nargs='+',
+                                help='List of channels from where to install')
+
+    # Uninstall packages
+    parser_uninstall = main_subparser.add_parser('uninstall',
+                                                 help='Uninstall packages in the '
+                                                      'virtual Python '
+                                                      'environment in the target '
+                                                      'directory.')
+    parser_uninstall.add_argument('packages', nargs='+',
+                                  help='List of packages to uninstall')
+
+    # List packages
+    parser_list = main_subparser.add_parser('list',
+                                            help='List packages available in the '
+                                                 'virtual Python '
+                                                 'environment in the target '
+                                                 'directory.')
+
+
+    options = parser.parse_args(args)
+    print(options)
+    manager = Manager(backend=options.backend,
+                      env_directory=options.env_directory)
+    
+    if options.command == 'create':
+        manager.create(packages=options.packages or ['python'],
+                       channels=options.channels)
+    elif options.command == 'install':
+        manager.install(packages=options.packages)
+    elif options.command == 'uninstall':
+        manager.uninstall(packages=options.packages)
+    elif options.command == 'list':
+        manager.list()

--- a/env_manager/cli.py
+++ b/env_manager/cli.py
@@ -16,8 +16,8 @@ def main(args=None):
                                                 'environment in a target '
                                                 'directory.')
     parser.add_argument('-b', '--backend',
-                        default=os.environ.get('ENV_BACKEND', 'MAMBA'),
-                        choices=['venv', 'mamba', 'micromamba],
+                        default=os.environ.get('ENV_BACKEND', 'mamba'),
+                        choices=list(Manager.BACKENDS.keys()),
                         help='The implementation to '
                              'create/manage a virtual '
                              'Python environment in the given '
@@ -76,8 +76,8 @@ def main(args=None):
                       env_directory=options.env_directory)
     
     if options.command == 'create':
-        manager.create(packages=options.packages or ['python'],
-                       channels=options.channels)
+        manager.create_environment(packages=options.packages or ['python'],
+                                   channels=options.channels)
     elif options.command == 'install':
         manager.install(packages=options.packages)
     elif options.command == 'uninstall':

--- a/env_manager/cli.py
+++ b/env_manager/cli.py
@@ -17,15 +17,16 @@ def main(args=None):
                                                 'directory.')
     parser.add_argument('-b', '--backend',
                         default=os.environ.get('ENV_BACKEND', 'MAMBA'),
-                        choices=['VENV', 'MAMBA', 'MICROMAMBA'],
+                        choices=['venv', 'mamba', 'micromamba],
                         help='The implementation to '
                              'create/manage a virtual '
                              'Python environment in the given '
                              'directory.')
     parser.add_argument('-ed', '--env_directory',
-                        default=os.environ.get('ENV_DIR',
-                                               osp.join(os.getcwd(), 'envs',
-                                                        str(uuid.uuid4()))),
+                        default=os.environ.get(
+                            'ENV_DIR',
+                            osp.join(os.getcwd(), 'envs', str(uuid.uuid4()))
+                        ),
                         help='A directory where the virtual environment '
                              'is or will be located following the structure '
                              '<base path>/envs/<env name>.')
@@ -33,7 +34,7 @@ def main(args=None):
     main_subparser = parser.add_subparsers(title='commands', dest='command')
     # Create env
     parser_create = main_subparser.add_parser('create',
-                                              help='Creates a virtual Python '
+                                              help='Create a virtual Python '
                                                    'environment in the target '
                                                    'directory.')
     parser_create.add_argument('--packages', nargs='+',
@@ -45,8 +46,8 @@ def main(args=None):
     parser_install = main_subparser.add_parser('install',
                                                help='Install packages in the '
                                                     'virtual Python '
-                                                    'environment in the target '
-                                                    'directory.')
+                                                    'environment placed in the '
+                                                    'target directory.')
     parser_install.add_argument('packages', nargs='+',
                                 help='List of packages to install')
     parser_install.add_argument('--channels', nargs='+',
@@ -56,8 +57,8 @@ def main(args=None):
     parser_uninstall = main_subparser.add_parser('uninstall',
                                                  help='Uninstall packages in the '
                                                       'virtual Python '
-                                                      'environment in the target '
-                                                      'directory.')
+                                                      'environment placed in the '
+                                                      'target directory.')
     parser_uninstall.add_argument('packages', nargs='+',
                                   help='List of packages to uninstall')
 
@@ -65,8 +66,8 @@ def main(args=None):
     parser_list = main_subparser.add_parser('list',
                                             help='List packages available in the '
                                                  'virtual Python '
-                                                 'environment in the target '
-                                                 'directory.')
+                                                 'environment placed in the '
+                                                 'target directory.')
 
 
     options = parser.parse_args(args)

--- a/env_manager/manager.py
+++ b/env_manager/manager.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT
+
+from env_manager.backends.mamba_interface import MambaInterface
+from env_manager.backends.venv_interface import VEnvInterface
+from env_manager.backends.micromamba_interface import MicromambaInterface
+
+
+class Manager:
+    BACKENDS = {
+        MambaInterface.ID: MambaInterface,
+        VEnvInterface.ID: VEnvInterface,
+        MicromambaInterface.ID: MicromambaInterface
+    }
+    def __init__(self, backend, env_directory, executable_path=None):
+        backend_class = self.BACKENDS[backend]
+        self.manager_instance = backend_class(executable_path=executable_path)
+        self.env_directory = env_directory
+
+    def create(self, packages=None, channels=None):
+        if channels:
+            self.manager_instance.create_environment(self.env_directory, packages, channels)
+        else:
+            self.manager_instance.create_environment(self.env_directory, packages)
+    
+    def install(self, packages=None, channels=None):
+        if channels:
+            self.manager_instance.install_packages(self.env_directory, packages, channels)
+        else:
+            self.manager_instance.install_packages(self.env_directory, packages)
+    
+    def uninstall(self, packages):
+        self.manager_instance.uninstall_packages(self.env_directory, packages)
+
+    def list(self):
+        return self.manager_instance.list_packages(self.env_directory)
+

--- a/env_manager/manager.py
+++ b/env_manager/manager.py
@@ -8,6 +8,9 @@ from env_manager.backends.micromamba_interface import MicromambaInterface
 
 
 class Manager:
+    """
+    Class to handle different Python environment and packages managers implementations.
+    """
     BACKENDS = {
         MambaInterface.ID: MambaInterface,
         VEnvInterface.ID: VEnvInterface,

--- a/env_manager/manager.py
+++ b/env_manager/manager.py
@@ -13,12 +13,13 @@ class Manager:
         VEnvInterface.ID: VEnvInterface,
         MicromambaInterface.ID: MicromambaInterface
     }
+
     def __init__(self, backend, env_directory, executable_path=None):
         backend_class = self.BACKENDS[backend]
         self.manager_instance = backend_class(executable_path=executable_path)
         self.env_directory = env_directory
 
-    def create(self, packages=None, channels=None):
+    def create_environment(self, packages=None, channels=None):
         if channels:
             self.manager_instance.create_environment(self.env_directory, packages, channels)
         else:

--- a/env_manager/tests/__init__.py
+++ b/env_manager/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT

--- a/env_manager/tests/test_cli.py
+++ b/env_manager/tests/test_cli.py
@@ -28,6 +28,6 @@ def test_cli_create(tmp_path):
     env_directory = envs_directory / "test_create"
     env_directory.mkdir(parents=True)
     create_output = subprocess.check_output(
-            ['env-manager', '-b=MAMBA', f'-ed={env_directory}', 'create']
+            ['env-manager', '-b=mamba', f'-ed={env_directory}', 'create']
         )
     assert 'Transaction finished' in str(create_output)

--- a/env_manager/tests/test_cli.py
+++ b/env_manager/tests/test_cli.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT
+
+import subprocess
+
+import pytest
+
+
+SUBCOMMANDS = [
+    '', 'create', 'install', 'uninstall', 'list',
+]
+
+
+@pytest.mark.parametrize('subcommand', SUBCOMMANDS)
+def test_cli_help(subcommand):
+    if subcommand:
+        subprocess.run(
+            ['env-manager', subcommand, '--help'], check=True,
+        )
+    else:
+        subprocess.run(
+            ['env-manager', '--help'], check=True,
+        )
+
+def test_cli_create(tmp_path):
+    envs_directory = tmp_path / "envs"
+    env_directory = envs_directory / "test_create"
+    env_directory.mkdir(parents=True)
+    create_output = subprocess.check_output(
+            ['env-manager', '-b=MAMBA', f'-ed={env_directory}', 'create']
+        )
+    assert 'Transaction finished' in str(create_output)

--- a/env_manager/tests/test_manager.py
+++ b/env_manager/tests/test_manager.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2022-present Spyder Development Team and env-manager contributors
+#
+# SPDX-License-Identifier: MIT
+
+import time
+
+import pytest
+
+from env_manager.manager import Manager
+
+
+# TODO: Add VENV and MICROMAMBA backends
+BACKENDS = [('MAMBA', 'mamba')]
+
+
+def wait_until(condition, interval=0.1, timeout=1):
+  start = time.time()
+  while not condition() and time.time() - start < timeout:
+    time.sleep(interval)
+
+
+@pytest.mark.parametrize('backend,package', BACKENDS)
+def test_manager_backends(backend, package, tmp_path):
+    envs_directory = tmp_path / "envs"
+    env_directory = envs_directory / f"test_{backend}"
+    env_directory.mkdir(parents=True)
+
+    manager = Manager(backend=backend, env_directory=env_directory)
+
+    # Create an environment with Python in it
+    manager.create(packages=['python'])
+    initial_list = manager.list()
+    assert 'python' in ' '.join(initial_list)
+
+    # Install a new package in the created environment
+    manager.install(packages=[package])
+    def package_installed():
+        package_list = manager.list()
+        return package in ' '.join(package_list)
+    wait_until(package_installed)
+
+    # TODO: Uninstall package from the created environment
+    # manager.uninstall(packages=[package])
+    # def package_uninstalled():
+    #     package_list = manager.list()
+    #     return package not in ' '.join(package_list)
+    # wait_until(package_uninstalled)

--- a/env_manager/tests/test_manager.py
+++ b/env_manager/tests/test_manager.py
@@ -9,8 +9,8 @@ import pytest
 from env_manager.manager import Manager
 
 
-# TODO: Add VENV and MICROMAMBA backends
-BACKENDS = [('MAMBA', 'mamba')]
+# TODO: Add 'venv' and 'micromamba' backends
+BACKENDS = [('mamba', 'mamba')]
 
 
 def wait_until(condition, interval=0.1, timeout=1):
@@ -28,7 +28,7 @@ def test_manager_backends(backend, package, tmp_path):
     manager = Manager(backend=backend, env_directory=env_directory)
 
     # Create an environment with Python in it
-    manager.create(packages=['python'])
+    manager.create_environment(packages=['python'])
     initial_list = manager.list()
     assert 'python' in ' '.join(initial_list)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = []
 dynamic = ["version"]
 
 [project.urls]
-Documentation = "https://github.com/unknown/env-manager#readme"
-Issues = "https://github.com/unknown/env-manager/issues"
-Source = "https://github.com/unknown/env-manager"
+Documentation = "https://github.com/spyder-ide/env-manager#readme"
+Issues = "https://github.com/spyder-ide/env-manager/issues"
+Source = "https://github.com/spyder-ide/env-manager"
 
 [project.scripts]
 env-manager = "env_manager.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = []
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,72 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "env-manager"
+description = ''
+readme = "README.md"
+requires-python = ">=3.7"
+license = "MIT"
+keywords = []
+authors = [
+  { name = "Spyder Development Team and env-manager contributors", email = "spyder.python@gmail.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = []
+dynamic = ["version"]
+
+[project.urls]
+Documentation = "https://github.com/unknown/env-manager#readme"
+Issues = "https://github.com/unknown/env-manager/issues"
+Source = "https://github.com/unknown/env-manager"
+
+[project.scripts]
+env-manager = "env_manager.cli:main"
+
+[project.optional-dependencies]
+test = [
+  "pytest",
+  "pytest-cov"
+]
+
+[tool.hatch.version]
+path = "env_manager/__about__.py"
+
+[tool.hatch.build.targets.sdist]
+[tool.hatch.build.targets.wheel]
+
+[tool.hatch.envs.default]
+dependencies = [
+  "pytest",
+  "pytest-cov",
+]
+[tool.hatch.envs.default.scripts]
+cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=env_manager --cov=tests"
+no-cov = "cov --no-cov"
+
+[[tool.hatch.envs.test.matrix]]
+python = ["37", "310"]
+
+[tool.coverage.run]
+branch = true
+parallel = true
+omit = [
+  "env_manager/__about__.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
This is an initial attempt to create a base structure for a package to help manage python envs/packages managers. Some sort of manager of managers/abstract manager instance. Some of the ideas here are:

* Create an abstract class that  defines the base functionality a Python env/packages manager should have (create an env, delete an env, install packages, remove packages, export/import an env, activate/deactivate an env, etc) to be used as a base class to create classes of the different Python env/packages managers.
* Have a CLI that enables using the different managers.
* Have a way to programatically setup and manage Python environments/packages being able to choose a specific manager (mamba, micromamba, venv + pip, conda, etc) but without worring about of the specfics of how that manager works.