### PR TITLE
PR: Fixes and improvements for final integration with Spyder

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -11,7 +11,7 @@ jobs:
   tests:
     name: Test Python ${{ matrix.python-version }}
     runs-on: windows-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
     strategy:

--- a/envs_manager/backends/api.py
+++ b/envs_manager/backends/api.py
@@ -108,12 +108,16 @@ class BackendInstance:
         environment_path: str,
         envs_directory: str,
         bin_directory: str,
+        python_version: str | None,
     ):
         self.environment_path = environment_path
         self.envs_directory = envs_directory
         self.bin_directory = bin_directory
+        self.python_version = python_version
+
         self.external_executable = None
         self.executable_variant = None
+
         assert self.validate(), f"{self.ID} backend unavailable!"
 
     @property

--- a/envs_manager/backends/conda_like_interface.py
+++ b/envs_manager/backends/conda_like_interface.py
@@ -78,7 +78,7 @@ class CondaLikeInterface(BackendInstance):
                         return False
                 return True
             except Exception as error:
-                logger.error(error.stderr)
+                logger.info(error.stderr)
 
         return False
 
@@ -222,7 +222,7 @@ class CondaLikeInterface(BackendInstance):
             logger.info(result.stdout)
             return BackendActionResult(status=True, output=result.stdout)
         except subprocess.CalledProcessError as error:
-            logger.error(error.stderr)
+            logger.info(error.stderr)
             return BackendActionResult(status=False, output=error.stderr)
         except Exception as error:
             return BackendActionResult(status=False, output=str(error))
@@ -254,7 +254,7 @@ class CondaLikeInterface(BackendInstance):
             logger.info(result.stdout)
             return BackendActionResult(status=True, output=result.stdout)
         except subprocess.CalledProcessError as error:
-            logger.error(error.stderr)
+            logger.info(error.stderr)
             return BackendActionResult(
                 status=False,
                 output=(
@@ -295,7 +295,7 @@ class CondaLikeInterface(BackendInstance):
                 status=True, output=result.stdout or result.stderr
             )
         except subprocess.CalledProcessError as error:
-            logger.error(error.stderr)
+            logger.info(error.stderr)
             return BackendActionResult(status=False, output=error.stderr)
         except Exception as error:
             return BackendActionResult(status=False, output=str(error))
@@ -319,7 +319,7 @@ class CondaLikeInterface(BackendInstance):
         except subprocess.CalledProcessError as error:
             if "PackagesNotFoundError" in error.stderr:
                 return BackendActionResult(status=True, output=error.stderr)
-            logger.error(error.stderr)
+            logger.info(error.stderr)
             return BackendActionResult(status=False, output=error.stderr)
         except Exception as error:
             return BackendActionResult(status=False, output=str(error))
@@ -344,7 +344,7 @@ class CondaLikeInterface(BackendInstance):
             else:
                 return BackendActionResult(status=True, output=result.stdout)
         except subprocess.CalledProcessError as error:
-            logger.error(error.stderr)
+            logger.info(error.stderr)
             return BackendActionResult(status=False, output=error.stderr)
         except Exception as error:
             return BackendActionResult(status=False, output=str(error))
@@ -428,7 +428,7 @@ class CondaLikeInterface(BackendInstance):
 
             return BackendActionResult(status=True, output=environments)
         except subprocess.CalledProcessError as error:
-            logger.error(error.stderr)
+            logger.info(error.stderr)
             return BackendActionResult(status=False, output=error.stderr)
         except Exception as error:
             return BackendActionResult(status=False, output=str(error))

--- a/envs_manager/backends/conda_like_interface.py
+++ b/envs_manager/backends/conda_like_interface.py
@@ -33,8 +33,10 @@ logger = logging.getLogger("envs-manager")
 class CondaLikeInterface(BackendInstance):
     ID = "conda-like"
 
-    def __init__(self, environment_path, envs_directory, bin_directory):
-        super().__init__(environment_path, envs_directory, bin_directory)
+    def __init__(self, environment_path, envs_directory, bin_directory, python_version):
+        super().__init__(
+            environment_path, envs_directory, bin_directory, python_version
+        )
 
         # This is needed for Micromamba
         os.environ["MAMBA_ROOT_PREFIX"] = str(Path(self.envs_directory).parent)
@@ -149,7 +151,13 @@ class CondaLikeInterface(BackendInstance):
             pass
 
     def create_environment(self, packages=None, channels=None, force=False):
-        command = [self.external_executable, "create", "-p", self.environment_path]
+        command = [
+            self.external_executable,
+            "create",
+            "-p",
+            self.environment_path,
+            f"python={self.python_version}" if self.python_version else "python",
+        ]
 
         packages = [] if packages is None else packages
         if packages:

--- a/envs_manager/backends/pixi_interface.py
+++ b/envs_manager/backends/pixi_interface.py
@@ -82,9 +82,9 @@ class PixiInterface(BackendInstance):
                 if parse(version) >= parse("0.47.0"):
                     return True
             except subprocess.CalledProcessError as error:
-                logger.error(error.stderr.strip())
+                logger.info(error.stderr.strip())
             except Exception as error:
-                logger.error(error, exc_info=True)
+                logger.info(error, exc_info=True)
 
         return False
 
@@ -121,10 +121,10 @@ class PixiInterface(BackendInstance):
                 cwd=self.bin_directory,
             )
         except subprocess.CalledProcessError as error:
-            logger.error(error.stderr.strip())
+            logger.info(error.stderr.strip())
             return
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             return
 
         # Cleanup
@@ -161,14 +161,14 @@ class PixiInterface(BackendInstance):
             logger.info(output.strip())
         except subprocess.CalledProcessError as error:
             error_text = error.stderr.strip()
-            logger.error(error_text)
+            logger.info(error_text)
             remove_path_error = self._remove_environment_path()
             return BackendActionResult(
                 status=False,
                 output=remove_path_error if remove_path_error else error_text,
             )
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             remove_path_error = self._remove_environment_path()
             return BackendActionResult(
                 status=False,
@@ -194,14 +194,14 @@ class PixiInterface(BackendInstance):
             return BackendActionResult(status=True, output=output)
         except subprocess.CalledProcessError as error:
             error_text = error.stderr.strip()
-            logger.error(error_text)
+            logger.info(error_text)
             remove_path_error = self._remove_environment_path()
             return BackendActionResult(
                 status=False,
                 output=remove_path_error if remove_path_error else error_text,
             )
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             remove_path_error = self._remove_environment_path()
             return BackendActionResult(
                 status=False,
@@ -225,10 +225,10 @@ class PixiInterface(BackendInstance):
             return BackendActionResult(status=True, output=result.stdout)
         except subprocess.CalledProcessError as error:
             error_text = error.stderr.strip()
-            logger.error(error_text)
+            logger.info(error_text)
             return BackendActionResult(status=False, output=error_text)
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             return BackendActionResult(status=False, output=str(error))
 
     def export_environment(self, export_file_path=None):
@@ -261,7 +261,7 @@ class PixiInterface(BackendInstance):
 
             return BackendActionResult(status=True, output=zip_content)
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             return BackendActionResult(status=False, output=str(error))
 
     def import_environment(self, import_file_path, force=False):
@@ -308,7 +308,7 @@ class PixiInterface(BackendInstance):
             with zipfile.ZipFile(import_file_path, "r") as zf:
                 zf.extractall(path=str(env_path))
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
 
             if remove_import_file:
                 try:
@@ -340,10 +340,10 @@ class PixiInterface(BackendInstance):
             return BackendActionResult(status=True, output=output)
         except subprocess.CalledProcessError as error:
             error_text = error.stderr.strip()
-            logger.error(error_text)
+            logger.info(error_text)
             return BackendActionResult(status=False, output=error_text)
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             return BackendActionResult(status=False, output=str(error))
 
     def install_packages(
@@ -371,10 +371,10 @@ class PixiInterface(BackendInstance):
                 logger.info((result.stdout or result.stderr).strip())
             except subprocess.CalledProcessError as error:
                 error_text = error.stderr.strip()
-                logger.error(error_text)
+                logger.info(error_text)
                 return BackendActionResult(status=False, output=error_text)
             except Exception as error:
-                logger.error(error, exc_info=True)
+                logger.info(error, exc_info=True)
                 return BackendActionResult(status=False, output=str(error))
 
         # Add packages
@@ -393,10 +393,10 @@ class PixiInterface(BackendInstance):
             return BackendActionResult(status=True, output=output if output else "")
         except subprocess.CalledProcessError as error:
             error_text = error.stderr.strip()
-            logger.error(error_text)
+            logger.info(error_text)
             return BackendActionResult(status=False, output=error_text)
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             return BackendActionResult(status=False, output=str(error))
 
     def uninstall_packages(self, packages, force=False, capture_output=False):
@@ -415,10 +415,10 @@ class PixiInterface(BackendInstance):
             return BackendActionResult(status=True, output=output if output else "")
         except subprocess.CalledProcessError as error:
             error_text = error.stderr.strip()
-            logger.error(error_text)
+            logger.info(error_text)
             return BackendActionResult(status=False, output=error_text)
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             return BackendActionResult(status=False, output=str(error))
 
     def update_packages(self, packages, force=False, capture_output=False):
@@ -438,10 +438,10 @@ class PixiInterface(BackendInstance):
                 return BackendActionResult(status=True, output="")
         except subprocess.CalledProcessError as error:
             error_text = error.stderr.strip()
-            logger.error(error_text)
+            logger.info(error_text)
             return BackendActionResult(status=False, output=error_text)
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             return BackendActionResult(status=False, output=str(error))
 
     def list_packages(self):
@@ -545,7 +545,7 @@ class PixiInterface(BackendInstance):
                 result = run_command(command, capture_output=True)
                 self._cache_dir = json.loads(result.stdout).get("cache_dir")
             except subprocess.CalledProcessError as error:
-                logger.error(error, exc_info=True)
+                logger.info(error, exc_info=True)
                 return
 
         if self._cache_dir is not None:
@@ -558,5 +558,5 @@ class PixiInterface(BackendInstance):
         try:
             shutil.rmtree(self.environment_path, ignore_errors=False)
         except Exception as error:
-            logger.error(error, exc_info=True)
+            logger.info(error, exc_info=True)
             return str(error)

--- a/envs_manager/backends/pixi_interface.py
+++ b/envs_manager/backends/pixi_interface.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import zipfile
 
@@ -161,10 +162,18 @@ class PixiInterface(BackendInstance):
         except subprocess.CalledProcessError as error:
             error_text = error.stderr.strip()
             logger.error(error_text)
-            return BackendActionResult(status=False, output=error_text)
+            remove_path_error = self._remove_environment_path()
+            return BackendActionResult(
+                status=False,
+                output=remove_path_error if remove_path_error else error_text,
+            )
         except Exception as error:
             logger.error(error, exc_info=True)
-            return BackendActionResult(status=False, output=str(error))
+            remove_path_error = self._remove_environment_path()
+            return BackendActionResult(
+                status=False,
+                output=remove_path_error if remove_path_error else str(error),
+            )
 
         command = [
             self.external_executable,
@@ -186,10 +195,18 @@ class PixiInterface(BackendInstance):
         except subprocess.CalledProcessError as error:
             error_text = error.stderr.strip()
             logger.error(error_text)
-            return BackendActionResult(status=False, output=error_text)
+            remove_path_error = self._remove_environment_path()
+            return BackendActionResult(
+                status=False,
+                output=remove_path_error if remove_path_error else error_text,
+            )
         except Exception as error:
             logger.error(error, exc_info=True)
-            return BackendActionResult(status=False, output=str(error))
+            remove_path_error = self._remove_environment_path()
+            return BackendActionResult(
+                status=False,
+                output=remove_path_error if remove_path_error else str(error),
+            )
 
     def delete_environment(self, force=False):
         # There is no command in Pixi to remove an env, so we rely on the OS
@@ -536,3 +553,10 @@ class PixiInterface(BackendInstance):
             info = AboutJson.from_package_directory(str(absolute_package_dir))
 
         return info
+
+    def _remove_environment_path(self):
+        try:
+            shutil.rmtree(self.environment_path, ignore_errors=False)
+        except Exception as error:
+            logger.error(error, exc_info=True)
+            return str(error)

--- a/envs_manager/backends/pixi_interface.py
+++ b/envs_manager/backends/pixi_interface.py
@@ -209,24 +209,10 @@ class PixiInterface(BackendInstance):
             )
 
     def delete_environment(self, force=False):
-        # There is no command in Pixi to remove an env, so we rely on the OS
-        # for that.
-        # TODO: Add validation on Windows when the env is in use
-        command = [
-            "rmdir" if os.name == "nt" else "rm",
-            "/S" if os.name == "nt" else "-r",  # Remove all files and subdirs
-            "/Q" if os.name == "nt" else "-f",  # Don't ask
-            self.environment_path,
-        ]
-
         try:
-            result = run_command(command, capture_output=True)
+            shutil.rmtree(self.environment_path, ignore_errors=False)
             logger.info(f"Deleting environment located at {self.environment_path}")
-            return BackendActionResult(status=True, output=result.stdout)
-        except subprocess.CalledProcessError as error:
-            error_text = error.stderr.strip()
-            logger.info(error_text)
-            return BackendActionResult(status=False, output=error_text)
+            return BackendActionResult(status=True, output="")
         except Exception as error:
             logger.info(error, exc_info=True)
             return BackendActionResult(status=False, output=str(error))

--- a/envs_manager/backends/pixi_interface.py
+++ b/envs_manager/backends/pixi_interface.py
@@ -40,8 +40,10 @@ def pyexec_from_pixi_env_path(path: Path) -> str:
 class PixiInterface(BackendInstance):
     ID = "pixi"
 
-    def __init__(self, environment_path, envs_directory, bin_directory):
-        super().__init__(environment_path, envs_directory, bin_directory)
+    def __init__(self, environment_path, envs_directory, bin_directory, python_version):
+        super().__init__(
+            environment_path, envs_directory, bin_directory, python_version
+        )
 
         # We use this to save the Pixi packages cache directory
         self._cache_dir = None
@@ -150,25 +152,30 @@ class PixiInterface(BackendInstance):
             logger.error(error, exc_info=True)
             return BackendActionResult(status=False, output=str(error))
 
+        command = [
+            self.external_executable,
+            "add",
+            f"python={self.python_version}" if self.python_version else "python",
+        ]
         if packages:
             if not isinstance(packages, list):
                 packages = [packages]
+            command = command + packages
 
-            command = [self.external_executable, "add"] + packages
-            try:
-                result = run_command(
-                    command, capture_output=True, cwd=self.environment_path
-                )
-                output = (result.stdout or result.stderr).strip()
-                logger.info(output)
-                return BackendActionResult(status=True, output=output)
-            except subprocess.CalledProcessError as error:
-                error_text = error.stderr.strip()
-                logger.error(error_text)
-                return BackendActionResult(status=False, output=error_text)
-            except Exception as error:
-                logger.error(error, exc_info=True)
-                return BackendActionResult(status=False, output=str(error))
+        try:
+            result = run_command(
+                command, capture_output=True, cwd=self.environment_path
+            )
+            output = (result.stdout or result.stderr).strip()
+            logger.info(output)
+            return BackendActionResult(status=True, output=output)
+        except subprocess.CalledProcessError as error:
+            error_text = error.stderr.strip()
+            logger.error(error_text)
+            return BackendActionResult(status=False, output=error_text)
+        except Exception as error:
+            logger.error(error, exc_info=True)
+            return BackendActionResult(status=False, output=str(error))
 
     def delete_environment(self, force=False):
         # There is no command in Pixi to remove an env, so we rely on the OS

--- a/envs_manager/backends/pixi_interface.py
+++ b/envs_manager/backends/pixi_interface.py
@@ -37,6 +37,20 @@ def pyexec_from_pixi_env_path(path: Path) -> str:
     return str(python_executable_path)
 
 
+def get_python_version_from_toml_file(path: Path) -> str:
+    """Get Python version from a given Pixi toml file."""
+    with open(path, "rb") as f:
+        pixi_toml = tomllib.load(f)
+
+    python_version = None
+    try:
+        python_version = pixi_toml["dependencies"]["python"].split(".*")[0]
+    except KeyError:
+        pass
+
+    return python_version
+
+
 class PixiInterface(BackendInstance):
     ID = "pixi"
 
@@ -473,11 +487,11 @@ class PixiInterface(BackendInstance):
         for env_dir_path in Path(self.envs_directory).iterdir():
             # Get Python version
             pixi_toml_path = env_dir_path / "pixi.toml"
+            python_version = get_python_version_from_toml_file(pixi_toml_path)
 
-            with open(pixi_toml_path, "rb") as f:
-                pixi_toml = tomllib.load(f)
-
-            python_version = pixi_toml["dependencies"]["python"].split(".*")[0]
+            # If the env doesn't have Python, we can't use it.
+            if python_version is None:
+                continue
 
             # Add env info to dict
             environments[env_dir_path.name] = (

--- a/envs_manager/backends/pixi_interface.py
+++ b/envs_manager/backends/pixi_interface.py
@@ -25,6 +25,18 @@ except ImportError:
 logger = logging.getLogger("envs-manager")
 
 
+def pyexec_from_pixi_env_path(path: Path) -> str:
+    """Return path to the Python executable given a Pixi environment path."""
+    pixi_env_dir = Path() / ".pixi" / "envs" / "default"
+
+    if os.name == "nt":
+        python_executable_path = path / pixi_env_dir / "python.exe"
+    else:
+        python_executable_path = path / pixi_env_dir / "bin" / "python"
+
+    return str(python_executable_path)
+
+
 class PixiInterface(BackendInstance):
     ID = "pixi"
 
@@ -36,18 +48,7 @@ class PixiInterface(BackendInstance):
 
     @property
     def python_executable_path(self):
-        pixi_env_dir = Path() / ".pixi" / "envs" / "default"
-
-        if os.name == "nt":
-            python_executable_path = (
-                Path(self.environment_path) / pixi_env_dir / "python.exe"
-            )
-        else:
-            python_executable_path = (
-                Path(self.environment_path) / pixi_env_dir / "bin" / "python"
-            )
-
-        return str(python_executable_path)
+        return pyexec_from_pixi_env_path(Path(self.environment_path))
 
     def validate(self):
         self.external_executable = self.find_backend_executable(exec_name="pixi")

--- a/envs_manager/backends/pixi_interface.py
+++ b/envs_manager/backends/pixi_interface.py
@@ -16,6 +16,11 @@ import requests
 
 from envs_manager.backends.api import BackendInstance, BackendActionResult, run_command
 
+try:
+    import tomllib  # Python 3.11+
+except ImportError:
+    import tomli as tomllib
+
 
 logger = logging.getLogger("envs-manager")
 
@@ -458,11 +463,27 @@ class PixiInterface(BackendInstance):
 
         logger.info(f"# {self.ID} environments")
         for env_dir_path in Path(self.envs_directory).iterdir():
-            environments[env_dir_path.name] = str(env_dir_path)
+            # Get Python version
+            pixi_toml_path = env_dir_path / "pixi.toml"
+
+            with open(pixi_toml_path, "rb") as f:
+                pixi_toml = tomllib.load(f)
+
+            python_version = pixi_toml["dependencies"]["python"].split(".*")[0]
+
+            # Add env info to dict
+            environments[env_dir_path.name] = (
+                str(env_dir_path),
+                f"Python {python_version}",
+            )
+
+            # Output printed to the console
             logger.info(f"{env_dir_path.name} - {str(env_dir_path)}")
 
         return BackendActionResult(status=True, output=environments)
 
+    # ---- Private API
+    # ----------------------------------------------------------------------------------
     def _get_package_info(self, package_dir):
         """
         Get package information from the Pixi packages cache.

--- a/envs_manager/backends/venv_interface.py
+++ b/envs_manager/backends/venv_interface.py
@@ -67,7 +67,8 @@ class VEnvInterface(BackendInstance):
                     packages.remove(possible_python)
                 if len(packages) > 0:
                     return self.install_packages(packages=packages)
-                return BackendActionResult(status=True, output=None)
+
+            return BackendActionResult(status=True, output=None)
         except Exception as error:
             return BackendActionResult(status=False, output=str(error))
 

--- a/envs_manager/cli.py
+++ b/envs_manager/cli.py
@@ -171,7 +171,7 @@ def main(args=None):
         )
         if options.command == "create":
             manager.create_environment(
-                packages=options.packages or ["python"], channels=options.channels
+                packages=options.packages, channels=options.channels
             )
         elif options.command == "delete":
             manager.delete_environment()

--- a/envs_manager/jupyter.py
+++ b/envs_manager/jupyter.py
@@ -37,6 +37,7 @@ class EnvManagerHandler(JupyterHandler):
             root_path=self.settings["envs_manager_config"]["root_path"],
             env_name=self.get_argument("env_name", None),
             env_directory=self.get_argument("env_directory", None),
+            python_version=self.get_argument("python_version", None),
         )
 
     def get_options(self) -> dict[str, t.Any]:

--- a/envs_manager/manager.py
+++ b/envs_manager/manager.py
@@ -214,6 +214,10 @@ class Manager:
         backend_result = self.backend_instance.list_environments()
         return self._backend_to_manager_result(backend_result)
 
+    def create_kernelspec(self, name: str) -> ManagerActionResult:
+        backend_result = self.backend_instance.create_kernelspec(name)
+        return self._backend_to_manager_result(backend_result)
+
     def _backend_to_manager_result(
         self,
         backend_result: BackendActionResult,

--- a/envs_manager/manager.py
+++ b/envs_manager/manager.py
@@ -58,6 +58,9 @@ class ManagerOptions(TypedDict):
     env_directory: str | None
     """Path to the environment's directory."""
 
+    python_version: str | None
+    """Python version for the environment."""
+
 
 class ManagerActionResult(BackendActionResult):
     """Dictionary to report the result of a manager's action."""
@@ -83,6 +86,7 @@ class Manager:
         root_path: str | Path | None = None,
         env_name: str | None = None,
         env_directory: str | Path | None = None,
+        python_version: str | None = None,
     ):
         self.backend_class = self.BACKENDS[backend]
         self.env_name = env_name
@@ -110,6 +114,7 @@ class Manager:
             str(self.env_directory),
             str(backend_envs_directory),
             str(bin_directory),
+            python_version,
         )
 
         self._manager_options = ManagerOptions(
@@ -117,6 +122,7 @@ class Manager:
             root_path=str(root_path),
             env_name=env_name,
             env_directory=str(self.env_directory),
+            python_version=python_version,
         )
 
     def run_action(self, action: ManagerActions, action_options: dict | None = None):

--- a/envs_manager/tests/test_manager.py
+++ b/envs_manager/tests/test_manager.py
@@ -251,6 +251,7 @@ def manager_instance(request, tmp_path):
         root_path=root_path,
         env_name=env_name,
         env_directory=env_directory,
+        python_version="3.10",
     )
     yield manager_instance
 
@@ -270,9 +271,7 @@ def manager_instance(request, tmp_path):
 def test_manager_backends_python_executable(manager_instance, capsys):
     # Create an environment with Python in it
     with capsys.disabled():
-        create_result = manager_instance.create_environment(
-            packages=["python==3.10"], force=True
-        )
+        create_result = manager_instance.create_environment(force=True)
     print(create_result["output"])
     assert create_result["status"]
 
@@ -302,9 +301,7 @@ def test_manager_backends(
 ):
     # Create an environment with Python in it
     with capsys.disabled():
-        create_result = manager_instance.create_environment(
-            packages=["python==3.10"], force=True
-        )
+        create_result = manager_instance.create_environment(force=True)
     assert create_result["status"]
 
     # List packages and check correct list result dimensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "py-rattler",
   "pyyaml",
   "requests",
+  "tomli; python_version < '3.11'",
 ]
 dynamic = ["version"]
 
@@ -86,7 +87,6 @@ exclude_lines = [
 ]
 
 [tool.black]
-py36 = true
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
- Fix importing env from bytes in Pixi backend.
- Add `create_kernelspec` method to the manager (needed for remote development).
- Return environments list in the format expected by Spyder (Pixi backend only for now).